### PR TITLE
[no jira] Fix manager node role in fresh install docs

### DIFF
--- a/content/docs/setup/getting-started/k0s-in-aws/terraform/controller.tf
+++ b/content/docs/setup/getting-started/k0s-in-aws/terraform/controller.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "cluster-controller" {
   instance_type = var.cluster_flavor
 
   tags = {
-    Name = "controller"
+    Name = "controller+worker"
   }
   key_name                    = aws_key_pair.cluster-key.key_name
   vpc_security_group_ids      = [aws_security_group.cluster_allow_ssh.id]


### PR DESCRIPTION
The terraform scripts in the `getting-started` docs used role `controller` which is not officially supported by MKE 4 yet. Manager nodes are expected to have `controller+worker` roles.