### PR TITLE
[BOP-821] Update allowed k0sctl versions

### DIFF
--- a/content/docs/setup/getting-started/install-mke4-cli.md
+++ b/content/docs/setup/getting-started/install-mke4-cli.md
@@ -14,8 +14,7 @@ additional dependencies, as of `MKE 4.0.0-alpha.1.0` the MKE CLI requires
 that you have the following tools installed on your system:
 
 - `kubectl`, version `1.29.0` or later ([download](https://kubernetes.io/docs/tasks/tools/#kubectl))
-- `k0sctl`, version `0.17.0` or later
-  ([download](https://github.com/k0sproject/k0sctl/releases))
+- `k0sctl`, version higher or equal to `0.17.0` but less than `0.18.0` ([download](https://github.com/k0sproject/k0sctl/releases))
 
 ## Install using a script
 


### PR DESCRIPTION
kubeconfig files generated by 0.18.0 use private IP addresses of the cluster nodes making it impossible to use such kubeconfig files from remote nodes (e.g. from local machine for clusters in AWS).

Thus, we should not allow using k0sctl 0.18.0. 