### PR TITLE
Fix made to MKE CLI install using script code-block.

### DIFF
--- a/content/docs/getting-started/install-MKE-CLI.md
+++ b/content/docs/getting-started/install-MKE-CLI.md
@@ -38,7 +38,7 @@ To automatically install the necessary dependencies, you can utilize the `instal
 1. Install the dependencies by downloading and executing the following shell script:
 
    ```shell
-   sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Mirantis/mke-docs/main/content/getting-started/install.sh)"
+   sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Mirantis/mke-docs/main/content/docs/getting-started/install.sh)"
     ```
 
    If you want to override default dependency versions, pass the `MKECTL_VERSION`, `KUBECTL_VERSION`


### PR DESCRIPTION
Edit made in reference to issues #67, #72, and #73, to fix link in code-block of Install MKE CLI with script.