### PR TITLE
fix: minor typo in SAML README

### DIFF
--- a/content/docs/operations/authentication/SAML-providers/SAML.md
+++ b/content/docs/operations/authentication/SAML-providers/SAML.md
@@ -17,7 +17,7 @@ For more information, refer to the official DEX documentation
 
 ## Configure MKE
 
-The MKE configuration file `authentication.smal` fields are detailed below:
+The MKE configuration file `authentication.saml` fields are detailed below:
 
 | Field                             | Description                                                                                                                                                                         |
 |-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
* fixes a filename typo in the `SAML.md` file