### PR TITLE
fix: URL used for 'Edit this page on GitHub'

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -104,4 +104,4 @@ params:
 
   editURL:
     enable: true
-    base: "https://github.com/Mirantis/mke-docs/edit/main/README.md"
+    base: "https://github.com/Mirantis/mke-docs/edit/main/content"


### PR DESCRIPTION
* fixes issue described in <https://github.com/Mirantis/mke-docs/issues/93>

Tested using local Hugo server, ie,

1. cd to repo root dir
2. run `hugo server`
3. navigate to <http://localhost:1313/mke-docs/>
4. navigate to [Docs](http://localhost:1313/mke-docs/docs/)
5. click "Edit this page on GitHub" ⇾ it will now correctly take you to <https://github.com/Mirantis/mke-docs/edit/main/content/docs/_index.md>
6. navigate to "Operations > Authentication > SAML" ⇾ it will now correctly take you to <https://github.com/Mirantis/mke-docs/edit/main/content/docs/operations/authentication/SAML-providers/SAML.md>