### PR TITLE
[BOP-1277] [Docs, MKE4] cadvisor

### DIFF
--- a/content/docs/operations/monitoring.md
+++ b/content/docs/operations/monitoring.md
@@ -20,10 +20,10 @@ Detail for the MKE 4 monitor tools is provided in the following table:
 ## Prometheus
 
 [Prometheus](https://prometheus.io/) is an open-source monitoring and alerting
-toolkit that is designed for reliability and scalability. It collects and stores metrics
-as time series data, providing powerful query capabilities and a flexible alerting system.
+toolkit, designed for reliability and scalability, that collects and stores metrics
+as time series data. It offers powerful query capabilities and a flexible alerting system.
 
-Prometheus API is available at `https://<mke4_url>/prometheus/` 
+The Prometheus API is available at `https://<mke4_url>/prometheus/`
 
 To access the Prometheus dashboard:
 
@@ -72,7 +72,7 @@ To access the Grafana dashboard:
 [cAdvisor](https://github.com/google/cadvisor) is an open-source tool that collects, aggregates, processes, 
 and exports information about running containers.
 
-cAdvisor is disabled in MKE by default and may be enabled through the MKE configuration file:
+cAdvisor is disabled in MKE by default. You can enable the tool through the MKE configuration file:
 
 ```yaml
 monitoring:

--- a/content/docs/operations/monitoring.md
+++ b/content/docs/operations/monitoring.md
@@ -44,7 +44,7 @@ Grafana is enabled in MKE by default and may be disabled through the MKE configu
 
 ```yaml
 monitoring:
-   enableGrafana: true
+  enableGrafana: true
 ```
 
 To access the Grafana dashboard:
@@ -70,13 +70,13 @@ To access the Grafana dashboard:
 ## cAdvisor
 
 [cAdvisor](https://github.com/google/cadvisor) is an open-source tool that collects, aggregates, processes, 
-and exports information about running containers.
+and exports information in reference to running containers.
 
 cAdvisor is disabled in MKE by default. You can enable the tool through the MKE configuration file:
 
 ```yaml
 monitoring:
-   enableCAdvisor: true
+  enableCAdvisor: true
 ```
 
 ## Opscare (Under development)
@@ -90,5 +90,5 @@ Disabled by default, you can enable Mirantis Opscare through the MKE configurati
 
 ```yaml
 monitoring:
-   enableOpscare: true
+  enableOpscare: true
 ```

--- a/content/docs/operations/monitoring.md
+++ b/content/docs/operations/monitoring.md
@@ -10,11 +10,30 @@ offering a comprehensive solution for collecting, storing, and visualizing metri
 
 Detail for the MKE 4 monitor tools is provided in the following table:
 
-| Monitoring tool    | Default state | Configuration key          | Description                                                                           |
-|------------|---------------|----------------------------|---------------------------------------------------------------------------------------|
-| Grafana    | enabled       | `monitoring.enableGrafana` | Provides a web interface for viewing metrics and logs collected by Prometheus         |
-| Prometheus | enabled       | -                          | Collects and stores metrics                                                           |
-| Opscare    | disabled      | `monitoring.enableOpscare` | (Under development) Supplies additional monitoring capabilities, such as Alertmanager |
+| Monitoring tool | Default state | Configuration key           | Description                                                                           |
+|-----------------|---------------|-----------------------------|---------------------------------------------------------------------------------------|
+| Prometheus      | enabled       | -                           | Collects and stores metrics                                                           |
+| Grafana         | enabled       | `monitoring.enableGrafana`  | Provides a web interface for viewing metrics and logs collected by Prometheus         |
+| cAdvisor        | disabled      | `monitoring.enableCAdvisor` | Provides additional container level metrics                                           |
+| Opscare         | disabled      | `monitoring.enableOpscare`  | (Under development) Supplies additional monitoring capabilities, such as Alertmanager |
+
+## Prometheus
+
+[Prometheus](https://prometheus.io/) is an open-source monitoring and alerting
+toolkit that is designed for reliability and scalability. It collects and stores metrics
+as time series data, providing powerful query capabilities and a flexible alerting system.
+
+Prometheus API is available at `https://<mke4_url>/prometheus/` 
+
+To access the Prometheus dashboard:
+
+1. Port forward Prometheus:
+
+    ```bash
+    kubectl --namespace mke port-forward svc/prometheus-operated 9090
+    ```
+
+2. Navigate to `http://localhost:9090`.
 
 ## Grafana
 
@@ -25,7 +44,7 @@ Grafana is enabled in MKE by default and may be disabled through the MKE configu
 
 ```yaml
 monitoring:
-  enableGrafana: true
+   enableGrafana: true
 ```
 
 To access the Grafana dashboard:
@@ -34,7 +53,8 @@ To access the Grafana dashboard:
 
    ```bash
    kubectl get secret monitoring-grafana -n mke -o jsonpath="{.data.admin-password}" | base64 --decode
-   
+   ```
+
 2. Port forward Grafana:
 
     ```bash
@@ -47,21 +67,17 @@ To access the Grafana dashboard:
 
 5. Click **Log In**.
    
-## Prometheus
+## cAdvisor
 
-[Prometheus](https://prometheus.io/) is an open-source monitoring and alerting
-toolkit that is designed for reliability and scalability. It collects and stores metrics
-as time series data, providing powerful query capabilities and a flexible alerting system.
+[cAdvisor](https://github.com/google/cadvisor) is an open-source tool that collects, aggregates, processes, 
+and exports information about running containers.
 
-To access the Prometheus dashboard:
+cAdvisor is disabled in MKE by default and may be enabled through the MKE configuration file:
 
-1. Port forward Prometheus:
-
-    ```bash
-    kubectl --namespace mke port-forward svc/prometheus-operated 9090
-    ```
-
-2. Navigate to `http://localhost:9090` to view the status page of Prometheus.
+```yaml
+monitoring:
+   enableCAdvisor: true
+```
 
 ## Opscare (Under development)
 
@@ -74,5 +90,5 @@ Disabled by default, you can enable Mirantis Opscare through the MKE configurati
 
 ```yaml
 monitoring:
-  enableOpscare: true
+   enableOpscare: true
 ```

--- a/content/docs/release-notes/known-issues.md
+++ b/content/docs/release-notes/known-issues.md
@@ -108,23 +108,23 @@ Use ``kubectl`` to change the ``Password`` object:
 
 ## [BOP-1299] Disk Usage and Memory metrics are not shown correctly in the dashboard with disabled cAdvisor
 
-When cAdvisor is disabled, on the main page of the dashboard, "Disk Usage" and "Memory" metrics have zero values.
+When cAdvisor is disabled, the main page of the dashboard presents a `0` value for the **Disk Usage** and  **Memory** metrics.
 
 **Workaround:**
 
-Enable cAdvisor in the config file and apply the config with `mkectl apply`
+Enable cAdvisor in the MKE configuration file and run `mkectl apply`.
 
 ```yaml
 monitoring:
    enableCAdvisor: true
 ```
 
-## [BOP-1299] Max Used Disk and Max CPU labels are swapped in the dashboard
+## [BOP-1299] Max Used Disk and Max CPU labels are swapped in the MKE dashboard
 
 No workaround is available at this time.
 
-## [BOP-1307] Prometheus can be access without authentication
+## [BOP-1307] Prometheus can be accessed without authentication
 
-Anyone who knows MKE 4 URL can access Prometheus without authentication.
+Any party with knowledge of the MKE 4 URL can access Prometheus without authentication.
 
 No workaround is available at this time.

--- a/content/docs/release-notes/known-issues.md
+++ b/content/docs/release-notes/known-issues.md
@@ -105,3 +105,26 @@ Use ``kubectl`` to change the ``Password`` object:
    userID: 7668fdb9-a979-4645-b6cc-10985df77da6
    username: admin
 3. Edit the ``hash`` field with the desired password hash.
+
+## [BOP-1299] Disk Usage and Memory metrics are not shown correctly in the dashboard with disabled cAdvisor
+
+When cAdvisor is disabled, on the main page of the dashboard, "Disk Usage" and "Memory" metrics have zero values.
+
+**Workaround:**
+
+Enable cAdvisor in the config file and apply the config with `mkectl apply`
+
+```yaml
+monitoring:
+   enableCAdvisor: true
+```
+
+## [BOP-1299] Max Used Disk and Max CPU labels are swapped in the dashboard
+
+No workaround is available at this time.
+
+## [BOP-1307] Prometheus can be access without authentication
+
+Anyone who knows MKE 4 URL can access Prometheus without authentication.
+
+No workaround is available at this time.

--- a/content/docs/release-notes/known-issues.md
+++ b/content/docs/release-notes/known-issues.md
@@ -108,7 +108,7 @@ Use ``kubectl`` to change the ``Password`` object:
 
 ## [BOP-1299] Disk Usage and Memory metrics are not shown correctly in the dashboard with disabled cAdvisor
 
-When cAdvisor is disabled, the main page of the dashboard presents a `0` value for the **Disk Usage** and  **Memory** metrics.
+When cAdvisor is disabled, the main page of the dashboard presents 0% as the value for the **Disk Usage** and  **Memory** metrics.
 
 **Workaround:**
 
@@ -116,7 +116,7 @@ Enable cAdvisor in the MKE configuration file and run `mkectl apply`.
 
 ```yaml
 monitoring:
-   enableCAdvisor: true
+  enableCAdvisor: true
 ```
 
 ## [BOP-1299] Max Used Disk and Max CPU labels are swapped in the MKE dashboard

--- a/content/docs/release-notes/known-issues.md
+++ b/content/docs/release-notes/known-issues.md
@@ -108,7 +108,7 @@ Use ``kubectl`` to change the ``Password`` object:
 
 ## [BOP-1299] Disk Usage and Memory metrics are not shown correctly in the dashboard with disabled cAdvisor
 
-When cAdvisor is disabled, the main page of the dashboard presents 0% as the value for the **Disk Usage** and  **Memory** metrics.
+When cAdvisor is disabled, the main page of the dashboard presents 0% as the value for the **Disk Usage** and **Memory** metrics.
 
 **Workaround:**
 


### PR DESCRIPTION
This PR adds cadvisor docs and a few related known issues

In MKE 3, we also provided a full list of cAdvisor metrics - https://docs.mirantis.com/mke/3.7/ops/administer-cluster/collect-cluster-metrics-prometheus/cadvisor-mke-metrics.html
We could have a similar page with all metrics in MKE 4 docs as well, but I am not sure if it is up-to-date and if MKE 4 provides the same list of metrics. @nsteph could you advise on that?