### PR TITLE
[BOP-1236] Remove instructions on direct config resource editing

### DIFF
--- a/content/docs/operations/telemetry.md
+++ b/content/docs/operations/telemetry.md
@@ -12,13 +12,17 @@ services.
 
 ## Enable telemetry through the MKE CLI
 
-Go to the `mkeconfig` object in the `mke` namespace and set `tracking.enabled` to `true`.
+In the MKE config file, set the `telemetry.enabled` field to `true` to enable telemetry.
 
-```bash
-kubectl edit mkeconfig -n mke
+```yaml
+spec:
+  tracking:
+    enabled: true
 ```
 
-`mke-operator` will take a few moments to reconcile the change in the
+Apply the new settings with `mkectl apply`.
+
+It will take a few moments to reconcile the change in the
 configuration, after which MKE will thereafter transmit key usage data to
 Mirantis by way of a secure Segment endpoint.
 

--- a/content/docs/operations/telemetry.md
+++ b/content/docs/operations/telemetry.md
@@ -14,12 +14,14 @@ services.
 
 1. Access the MKE configuration file.
 2. Set the `telemetry.enabled` field to `true`.
+
    ```yaml
    spec:
      tracking:
        enabled: true
    ```
-3. Run the  `mkectl apply` command to apply the new settings.
+
+4. Run the  `mkectl apply` command to apply the new settings.
 
 After a few moments, the change will reconcile in the configuration. From this point onward,
 MKE will transmit key usage data to Mirantis by way of a secure Segment endpoint.

--- a/content/docs/operations/telemetry.md
+++ b/content/docs/operations/telemetry.md
@@ -12,19 +12,17 @@ services.
 
 ## Enable telemetry through the MKE CLI
 
-In the MKE config file, set the `telemetry.enabled` field to `true` to enable telemetry.
+1. Access the MKE configuration file.
+2. Set the `telemetry.enabled` field to `true`.
+   ```yaml
+   spec:
+     tracking:
+       enabled: true
+   ```
+3. Run the  `mkectl apply` command to apply the new settings.
 
-```yaml
-spec:
-  tracking:
-    enabled: true
-```
-
-Apply the new settings with `mkectl apply`.
-
-It will take a few moments to reconcile the change in the
-configuration, after which MKE will thereafter transmit key usage data to
-Mirantis by way of a secure Segment endpoint.
+After a few moments, the change will reconcile in the configuration. From this point onward,
+MKE will transmit key usage data to Mirantis by way of a secure Segment endpoint.
 
 ## Enable telemetry through the MKE web UI
 


### PR DESCRIPTION
We should **never** tell users to modify the config resource directly.

**All changes to the config must be done via mkectl apply or UI**

`kubectl edit` of the config file may lead to errors and instabilities in the cluster and should only be done by an experienced MKE 4 developer or support team member. Users should not attempt editing the config resource by themselves, and our documentation should not advertise this way of modifying the config.