### PR TITLE
Changed icon in Configuration index to cog

### DIFF
--- a/content/docs/configuration/_index.md
+++ b/content/docs/configuration/_index.md
@@ -6,18 +6,18 @@ weight: 3
 The information herein is designed to guide you in setting up, maintaining, and running MKE 4.
 
 {{< cards >}}
-{{< card link="authentication" title="Authentication" icon="lightning-bolt" >}}
-{{< card link="backup-restore" title="Backup and restore" icon="lightning-bolt" >}}
-{{< card link="mke-virtualization" title="MKE Virtualization" icon="lightning-bolt" >}}
-{{< card link="kubernetes" title="Kubernetes Components" icon="lightning-bolt" >}}
-{{< card link="ingress" title="Ingress controller" icon="lightning-bolt" >}}
-{{< card link="monitoring" title="Monitoring" icon="lightning-bolt" >}}
-{{< card link="support-bundle" title="Support bundle" icon="lightning-bolt" >}}
-{{< card link="telemetry" title="Telemetry" icon="lightning-bolt" >}}
-{{< card link="coredns-lameduck" title="CoreDNS Lameduck" icon="lightning-bolt" >}}
-{{< card link="dashboard" title="MKE Dashboard" icon="lightning-bolt" >}}
-{{< card link="nvidia-gpu" title="NVIDIA GPU Workloads" icon="lightning-bolt">}}
+{{< card link="authentication" title="Authentication" icon="cog" >}}
+{{< card link="backup-restore" title="Backup and restore" icon="cog" >}}
+{{< card link="mke-virtualization" title="MKE Virtualization" icon="cog" >}}
+{{< card link="kubernetes" title="Kubernetes Components" icon="cog" >}}
+{{< card link="ingress" title="Ingress controller" icon="cog" >}}
+{{< card link="monitoring" title="Monitoring" icon="cog" >}}
+{{< card link="support-bundle" title="Support bundle" icon="cog" >}}
+{{< card link="telemetry" title="Telemetry" icon="cog" >}}
+{{< card link="coredns-lameduck" title="CoreDNS Lameduck" icon="cog" >}}
+{{< card link="dashboard" title="MKE Dashboard" icon="cog" >}}
+{{< card link="nvidia-gpu" title="NVIDIA GPU Workloads" icon="cog">}}
 {{< card link="policycontroller" title="Policy Controller"
-icon="lightning-bolt" >}}
-{{< card link="cloudproviders" title="Cloud Providers" icon="lightning-bolt" >}}
+icon="cog" >}}
+{{< card link="cloudproviders" title="Cloud Providers" icon="cog" >}}
 {{< /cards >}}


### PR DESCRIPTION
Changed icons to a more fitting cogs for the Configuration section index.

<img width="960" alt="image" src="https://github.com/user-attachments/assets/aa7b5eac-3064-4149-b6de-991e54eb8239">
