### PR TITLE
[BOP-1429] Add telemetry information about k0s

### DIFF
--- a/content/docs/configuration/telemetry.md
+++ b/content/docs/configuration/telemetry.md
@@ -11,8 +11,7 @@ helps product teams in their efforts to enhance Mirantis products and
 services.
 
 {{< callout type="info" >}}
-    Enabling or disabling telemetry in MKE automatically applies the setting
-    to the k0s configuration. 
+    The MKE 4 telemetry enablement setting is automatically applied to the k0s configuration. 
 {{< /callout >}}
 
 {{< callout type="info" >}}

--- a/content/docs/configuration/telemetry.md
+++ b/content/docs/configuration/telemetry.md
@@ -11,6 +11,11 @@ helps product teams in their efforts to enhance Mirantis products and
 services.
 
 {{< callout type="info" >}}
+    Enabling or disabling telemetry in MKE automatically applies the setting
+    to the k0s configuration. 
+{{< /callout >}}
+
+{{< callout type="info" >}}
    Telemetry is automatically enabled for MKE 4 clusters that are running
    without a license, with a license that has expired, or with an invalid
    license. In all of such scenarios, you can only disable


### PR DESCRIPTION
Add doc to call out that MKE 4 telemetry settings are applied to the k0s configuration as well. 