### PR TITLE
Update authentication config examples

### DIFF
--- a/content/docs/configuration/authentication/LDAP.md
+++ b/content/docs/configuration/authentication/LDAP.md
@@ -10,7 +10,6 @@ LDAP example configuration:
 
 ```yaml
 authentication:
-  enabled: true
   ldap:
     enabled: true
     host: ldap.example.org:389

--- a/content/docs/configuration/authentication/OIDC.md
+++ b/content/docs/configuration/authentication/OIDC.md
@@ -16,7 +16,6 @@ authentication:
     issuer: https://dev-94406016.okta.com
     clientID: 0oedtjcjrjWab3zlD5d4
     clientSecret: DFA9NYLfE1QxwCSFkZunssh2HCx16kDl41k9tIBtFZaNcqyEGle8yZPtMBesyomD
-    redirectURI: http://dex.example.com/dex/callback
 ```
 
 ## Configure OIDC service for MKE

--- a/content/docs/configuration/authentication/OIDC.md
+++ b/content/docs/configuration/authentication/OIDC.md
@@ -10,7 +10,6 @@ OIDC example configuration:
 
 ```yaml
 authentication:
-  enabled: true
   oidc:
     enabled: true
     issuer: https://dev-94406016.okta.com

--- a/content/docs/configuration/authentication/SAML.md
+++ b/content/docs/configuration/authentication/SAML.md
@@ -13,7 +13,6 @@ authentication:
   saml:
     enabled: true
     ssoURL: https://dev64105006.okta.com/app/dev64105006_mke4saml_1/epkdtszgindywD6mF5s7/sso/saml
-    redirectURI: http://www.example.com/dex/callback
     usernameAttr: name
     emailAttr: email
 ```

--- a/content/docs/configuration/authentication/_index.md
+++ b/content/docs/configuration/authentication/_index.md
@@ -36,7 +36,6 @@ authentication protocol, set its `enabled` configuration option to `true`.
 
 ```yaml
 authentication:
-  enabled: true
   ldap:
     enabled: false
   oidc:
@@ -49,7 +48,6 @@ You can use the `expiry` section of the configuration file to set the expiration
 
 ```yaml
 authentication:
-  enabled: true
   expiry:
     refreshTokens: {}
 ```


### PR DESCRIPTION
Removes the `enabled` and `redirectURI` from the config examples