### PR TITLE
Remove download link for mkectl windows binary

### DIFF
--- a/content/docs/getting-started/install-MKE-CLI.md
+++ b/content/docs/getting-started/install-MKE-CLI.md
@@ -115,7 +115,6 @@ Download `mkectl` from the S3 bucket:
 | ------------ | ------------ | ----------------------------------------------------------------------------------------------------------------- |
 | Linux        | x86_64       | [download](https://github.com/mirantiscontainers/mke-release/releases/latest/download/mkectl_linux_x86_64.tar.gz) |
 | MacOS        | x86_64       | [download](https://github.com/mirantiscontainers/mke-release/releases/latest/download/mkectl_darwin_arm64.tar.gz) |
-| Windows      | x86_64       | [download](https://github.com/mirantiscontainers/mke-release/releases/latest/download/mkectl_windows_x86_64.zip)  |
 
 The MKE CLI is a single binary that is capable of managing MKE clusters without
 any additional dependencies. Its use, though, requires that you have the


### PR DESCRIPTION
We provide a link to download mkectl for windows, but we never tested it, and windows is not officially supported by mkectl, so this PR removes the link

![image](https://github.com/user-attachments/assets/c3af9c08-bea9-4900-9aae-89644a680a92)
