### PR TITLE
Update upload-artifacts to v4

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Upload artifact
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_CI_BOUNDLESS }}
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 


### PR DESCRIPTION
The upload-artifacts GHA has deprecated all versions <3. This PR updates the version so the docs action works again

**Note**
I didn't update any of the versions in the theme folder because 
- We aren't running the theme's actions
- The theme should be updated with its actual version, not our individual modifications 