### PR TITLE
Sync artifact upload and deploy versions

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -57,6 +57,7 @@ jobs:
       - name: Upload artifact
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_CI_BOUNDLESS }}
+        # Version depends on actions/deploy-pages version below
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
@@ -72,4 +73,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        # Version depends on actions/upload-pages-artifact version below
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update `actions/deploy-pages` to V4
Update `actions/upload-pages-artifact` to V3

These actions require compatibility with one another. Reference their docs for more information.