### PR TITLE
update cni documentation for MKE 4.1

### DIFF
--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -242,4 +242,4 @@ The network configuration generated as a result of upgrading to MKE 4 from an ex
 
 - MKE4 does not support Calico Enterprise. 
 - Only clusters that use the default Kubernetes proxier `iptables` can be upgraded from MKE3 to MKE4.
-- Only KDD-backed MKE 3 clusters can be upgraded to MKE 4.
+- Only KDD-backed MKE 3 clusters can be upgraded to MKE 4. Refer to [Upgrade from MKE 3.x](../../upgrade-from-MKE-3) for more information.

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -90,11 +90,7 @@ for the Calico provider.
 | `linuxDataplane` | Sets the dataplane for Calico CNI. | Iptables | Iptables|
 | `loglevel` | Sets the log level for the CNI components. | Info, Debug | Info|
 
-The above configuration should suffice if you are OK with the default networking configuration and/or
-desire to minimize efforts around network configuration. However if you want the ability to configure
-networking beyond the above, MKE4 also exposes maximal configuration for the Calico provider. This allows
-you to configure networking to the fullest extent allowed by the Calico CNI. To do this, you need to use
-the values.yaml key. An example networking would then look like the following:
+The default network configuration described herein offers a serviceable, low maintenance solution. If, however, you want more control over your network configuration environment, MKE 4 exposes maximal configuration for the Calico CNI through which you can configure your networking to the fullest extent allowed by the provider. For this, you will use the `values.yaml` key, in which case an example networking would resemble the following:
 
 ```yaml
  network:

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -69,7 +69,7 @@ The following table includes details on all of the configurable `network` fields
 
 ## CNI providers configuration
 
-### Kuberouter
+### Kube-router
 
 Configuration for the kube-router CNI can be done by referring to the
 documentation in https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#command-line-options. 

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -71,7 +71,7 @@ The following table includes details on all of the configurable `network` fields
 
 ### Kube-router
 
-Configuration for the kube-router CNI can be done by referring to the
+Configuration for the Kube-router CNI can be done by referring to the
 documentation in https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#command-line-options. 
 
 Two parameters [cidrV4 and v] are used to specify the ipv4 cidr and log level for the cluster.

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -3,13 +3,16 @@ title: Container Network Interface
 weight: 4
 ---
 
-MKE supports Calico open-source as a Container Network Interface (CNI) plugin
+MKE supports the following Container Network Interface (CNI) plugins
 to enable the networking functionalities needed for container communication
-and management within a cluster.
+and management within a cluster:
+
+1. Calico OSS
+2. Kuberouter
 
 {{< callout type="warning" >}}
 
-Calico configuration is not migrated during the MKE3 to MKE4 upgrade.
+Only Calico OSS CNI is supported for migrating configuration during the MKE3 to MKE4 upgrade.
 
 {{< /callout >}}
 
@@ -18,60 +21,44 @@ Calico configuration is not migrated during the MKE3 to MKE4 upgrade.
 The `network` section of the MKE configuration file renders as follows:
 
 ```yaml
-network:
-  serviceCIDR: 10.96.0.0/16
-  nodePortRange: 32768-35535
-  kubeProxy:
-    disabled: false
-    mode: iptables
-    metricsbindaddress: 0.0.0.0:10249
-    iptables:
-      masqueradebit: null
-      masqueradeall: false
-      localhostnodeports: null
-      syncperiod:
-        duration: 0s
-      minsyncperiod:
-        duration: 0s
-    ipvs:
-      syncperiod:
-        duration: 0s
-      minsyncperiod:
-        duration: 0s
-      scheduler: ""
-      excludecidrs: []
-      strictarp: false
-      tcptimeout:
-        duration: 0s
-      tcpfintimeout:
-        duration: 0s
-      udptimeout:
-        duration: 0s
-    nodeportaddresses: []
-  nllb:
-    disabled: true
-  cplb:
-    disabled: true
-  providers:
-  - provider: calico
-    enabled: true
-    CALICO_DISABLE_FILE_LOGGING: true
-    CALICO_STARTUP_LOGLEVEL: DEBUG
-    FELIX_LOGSEVERITYSCREEN: DEBUG
-    clusterCIDRIPv4: 192.168.0.0/16
-    deployWithOperator: false
-    enableWireguard: false
-    ipAutodetectionMethod: null
-    mode: vxlan
-    overlay: Always
-    vxlanPort: 4789
-    vxlanVNI: 10000
-  - provider: kuberouter
-    enabled: false
-    deployWithOperator: false
-  - provider: custom
-    enabled: false
-    deployWithOperator: false
+ network:
+    cplb:
+      disabled: true
+    kubeProxy:
+      iptables:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+      ipvs:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+        tcpFinTimeout: 0s
+        tcpTimeout: 0s
+        udpTimeout: 0s
+      metricsBindAddress: 0.0.0.0:10249
+      mode: iptables
+      nftables:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+    multus:
+      enabled: false
+    nllb:
+      disabled: true
+    nodePortRange: 32768-35535
+    serviceCIDR: 10.96.0.0/16
+    providers:
+    - enabled: true
+      extraConfig:
+        cidrV4: 192.168.0.0/16
+        linuxDataplane: Iptables
+        loglevel: Info
+      provider: calico
+    - enabled: false
+      provider: custom
+    - enabled: false
+      extraConfig:
+        cidrV4: 192.168.0.0/16
+        v: "5"
+      provider: kuberouter
 ```
 
 ## Network configuration
@@ -85,23 +72,163 @@ The following table includes details on all of the configurable `network` fields
 
 ## Providers configuration
 
+### Kuberouter CNI
+
+Configuration for the kube-router CNI can be done by referring to the
+documentation in https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#command-line-options. 
+
+Two parameters [cidrV4 and v] are used to specify the ipv4 cidr and log level for the cluster.
+Any other parameters specified in the extraConfig section of the CNI are passed as-is in the form 
+of a key value pair by appending '--' before the key.
+
+### Calico CNI
+
 The following table includes details on the configurable settings
 for the Calico provider.
 
 | Field   | Description  | Values        |  Default     |
 |---------|--------------|---------------|--------------|
 | `enabled` | Sets the name of the external storage provider. AWS is currently the only available option. | `true` | `true` |
-| `clusterCIDRIPv4` | Sets the IP pool in the Kubernetes cluster from which Pods are allocated. | Valid IPv4 CIDR | `192.168.0.0/16` <br><br>You can easily modify `clusterCIDRIPv4` prior to cluster deployment. Contact Mirantis Support, however, if you need to modify `clusterCIDRIPv4` once your cluster has been deployed.|
-| `ipAutodetectionMethod` | Sets the autodetecting method for the IPv4 address for the host. | Provider specific[^0] | None |
-| `mode` | Sets the IPv4 overlay networking mode.[^1] | `ipip`, `vxlan` | `vxlan` |
-| `vxlanPort` | Sets the VXLAN port for the VXLAN mode. | Valid port number | `4789` |
-| `vxlanVNI` | Sets the VXLAN VNI for the VXLAN mode. | Valid VNI number | `10000` |
-| `CALICO_STARTUP_LOGLEVEL` | Sets the early log level for `calico/node`. | Provider specific[^0] | `DEBUG` |
-| `FELIX_LOGSEVERITYSCREEN` | Sets the log level for `calico/felix`. | Provider specific[^0] | `DEBUG` |
+| `cidrV4` | Sets the IP pool in the Kubernetes cluster from which Pods are allocated. | Valid IPv4 CIDR | `192.168.0.0/16` <br><br>You can easily modify `cidrV4` prior to cluster deployment. Contact Mirantis Support, however, if you need to modify `clusterCIDRIPv4` once your cluster has been deployed.|
+| `linuxDataplane` | Sets the dataplane for Calico CNI. | Iptables | Iptables|
+| `loglevel` | Sets the log level for the CNI components. | Info, Debug | Info|
 
-[^0]: Refer to your Calico provider documentation for the available values.
+The above configuration should suffice if you are OK with the default networking configuration and/or
+desire to minimize efforts around network configuration. However if you want the ability to configure
+networking beyond the above, MKE4 also exposes maximal configuration for the Calico provider. This allows
+you to configure networking to the fullest extent allowed by the Calico CNI. To do this, you need to use
+the values.yaml key. An example networking would then look like the following:
 
-[^1]: MKE4 does not support `mode` field modifications following installation.
+```yaml
+ network:
+    cplb:
+      disabled: true
+    kubeProxy:
+      iptables:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+      ipvs:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+        tcpFinTimeout: 0s
+        tcpTimeout: 0s
+        udpTimeout: 0s
+      metricsBindAddress: 0.0.0.0:10249
+      mode: iptables
+      nftables:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+    multus:
+      enabled: false
+    nllb:
+      disabled: true
+    nodePortRange: 32768-35535
+    serviceCIDR: 10.96.0.0/16
+    providers:
+    - enabled: true
+      extraConfig:
+        loglevel: Info
+        values.yaml: |-
+          kubeletVolumePluginPath: /var/lib/k0s/kubelet
+          installation:
+            logging:
+              cni:
+                logSeverity: Debug
+            cni:
+              type: Calico
+            calicoNetwork:
+              linuxDataplane: Iptables
+              ipPools:
+              - cidr: 192.168.0.0/15
+                encapsulation: VXLAN
+          resources:
+            requests:
+              cpu: 250m
+          defaultFelixConfiguration:
+            enabled: true
+            wireguardEnabled: false
+            wireguardEnabledV6: false
+      provider: calico
+    - enabled: false
+      provider: custom
+    - enabled: false
+      extraConfig:
+        cidrV4: 192.168.0.0/16
+        v: "5"
+      provider: kuberouter
+```
+
+[^0]: The choice of whether to specify exact yaml spec for Helm installation of tigera-operator must be made while initially installing the cluster
+[^1]: MKE4 installation will fail if the supplied yaml for values.yaml does not include the exact first line `kubeletVolumePluginPath: /var/lib/k0s/kubelet`
+[^2]  The full values.yaml spec for the Helm chart used to install tigera-operator can be seen in https://github.com/projectcalico/calico/blob/master/charts/tigera-operator/values.yaml. Refer to 
+      Calico OSS documentation for tigera-operator to prepare the required contents in values.yaml. MKE4 does not mangle the yaml provided in values.yaml before passing it to the Helm installer
+[^3]: Refer to https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation for installation contents in values.yaml
+[^4]: Refer to https://docs.tigera.io/calico/latest/reference/resources/felixconfig for defaultFelixConfiguration contents in values.yaml
+[^5]: The network configuration generated after migrating an existing MKE3 cluster will always use yaml. However because such cluster have at least one existing ip pool, the cidr and dataplane 
+      values will be specified outside of the yaml as shown below:
+
+```yaml
+  network:
+    cplb:
+      disabled: true
+    kubeProxy:
+      iptables:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+      ipvs:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+        tcpFinTimeout: 0s
+        tcpTimeout: 0s
+        udpTimeout: 0s
+      metricsBindAddress: 0.0.0.0:10249
+      mode: iptables
+      nftables:
+        minSyncPeriod: 0s
+        syncPeriod: 0s
+    multus:
+      enabled: false
+    nllb:
+      disabled: true
+    nodePortRange: 30000-32768
+    serviceCIDR: 10.96.0.0/16
+    providers: 
+    - enabled: true
+      extraConfig:
+        cidrV4: 192.168.0.0/15
+        linuxDataplane: Iptables
+        loglevel: DEBUG
+        values.yaml: |-
+          kubeletVolumePluginPath: /var/lib/k0s/kubelet
+          installation:
+            registry: ghcr.io/mirantiscontainers/
+            cni:
+              type: Calico
+            calicoNetwork:
+              bgp: Disabled
+              linuxDataplane: Iptables
+          resources:
+            requests:
+              cpu: 250m
+          tigeraOperator:
+            version: v1.37.1
+            registry: ghcr.io/mirantiscontainers/
+          defaultFelixConfiguration:
+            enabled: true
+            bpfConnectTimeLoadBalancing: TCP
+            bpfHostNetworkedNATWithoutCTLB: Enabled
+            bpfLogLevel: Debug
+            floatingIPs: Disabled
+            logSeverityScreen: Debug
+            logSeveritySys: Debug
+            reportingInterval: 0s
+            vxlanPort: 4789
+            vxlanVNI: 10037
+      provider: calico
+    - enabled: false
+      provider: custom
+```
+
 
 {{< callout type="info" >}}
 - MKE4 uses a static port range for Kubernetes NodePorts, from  `32768` to `35535`. 
@@ -112,6 +239,4 @@ for the Calico provider.
 
 - MKE4 does not support Calico Enterprise. 
 - Only clusters that use the default Kubernetes proxier `iptables` can be upgraded from MKE3 to MKE4.
-- As MKE4 uses KDD as a networking datastore, you may notice degraded
-  networking performance degradation on cluster sizes in excess of 100 nodes.
 - Only KDD-backed MKE3 clusters can be upgraded to MKE4.

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -156,7 +156,7 @@ The default network configuration described herein offers a serviceable, low mai
 - You must choose whether to specify an exact YAML specification for the Helm installation of Tigera Operator during the initial cluster installation.
 - The supplied yaml for `values.yaml` must include the exact first line `kubeletVolumePluginPath: /var/lib/k0s/kubelet`, otherwise the MKE 4 installation will fail.
 
-{< /callout >}}
+{{< /callout >}}
 
 {{< callout type="info" >}} Refer to the official Tigera Operator documentation
 for:

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -78,7 +78,7 @@ Two parameters [cidrV4 and v] are used to specify the ipv4 cidr and log level fo
 Any other parameters specified in the extraConfig section of the CNI are passed as-is in the form 
 of a key value pair by appending '--' before the key.
 
-### Calico CNI
+### Calico OSS
 
 The following table includes details on the configurable settings
 for the Calico provider.

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -165,7 +165,7 @@ for:
 - The [`values.yaml` information content](https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation)
 - The [`defaultFelixConfiguration` content for the `values.yaml` specification(https://docs.tigera.io/calico/latest/reference/resources/felixconfig)
 
-You can  view the full `values.yaml` specification for the Helm chart needed to install Tigera Operator at the [Project Calico GitHub](https://github.com/projectcalico/calico/blob/master/charts/tigera-operator/values.yaml).
+You can view the full `values.yaml` specification for the Helm chart needed to install Tigera Operator at the [Project Calico GitHub](https://github.com/projectcalico/calico/blob/master/charts/tigera-operator/values.yaml).
 
 {{< /callout >}}
 The network configuration generated as a result of upgrading to MKE 4 from an existing MKE 3 cluster always uses yaml. As such clusters have at least one existing IP pool, however, the CIDR and dataplane values are specified outside of the yaml, as illustrated below:

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -3,7 +3,7 @@ title: Container Network Interface
 weight: 4
 ---
 
-MKE supports both the Kuberouter and Calico OSS Container Network Interface (CNI) plugins,
+MKE supports both the Kube-router and Calico OSS Container Network Interface (CNI) plugins,
 to enable the networking functionalities needed for container communication
 and management within a cluster.
 

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -157,8 +157,7 @@ The default network configuration described herein offers a serviceable, low mai
       Calico OSS documentation for tigera-operator to prepare the required contents in values.yaml. MKE4 does not mangle the yaml provided in values.yaml before passing it to the Helm installer
 [^3]: Refer to https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation for installation contents in values.yaml
 [^4]: Refer to https://docs.tigera.io/calico/latest/reference/resources/felixconfig for defaultFelixConfiguration contents in values.yaml
-[^5]: The network configuration generated after migrating an existing MKE3 cluster will always use yaml. However because such cluster have at least one existing ip pool, the cidr and dataplane 
-      values will be specified outside of the yaml as shown below:
+The network configuration generated as a result of upgrading to MKE 4 from an existing MKE 3 cluster always uses yaml. As such clusters have at least one existing IP pool, however, the CIDR and dataplane values are specified outside of the yaml, as illustrated below:
 
 ```yaml
   network:

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -168,7 +168,7 @@ for:
 You can view the full `values.yaml` specification for the Helm chart needed to install Tigera Operator at the [Project Calico GitHub](https://github.com/projectcalico/calico/blob/master/charts/tigera-operator/values.yaml).
 
 {{< /callout >}}
-The network configuration generated as a result of upgrading to MKE 4 from an existing MKE 3 cluster always uses yaml. As such clusters have at least one existing IP pool, however, the CIDR and dataplane values are specified outside of the yaml, as illustrated below:
+The network configuration generated as a result of upgrading to MKE 4 from an existing MKE 3 cluster always uses YAML. As such clusters have at least one existing IP pool, however, the CIDR and dataplane values are specified outside of the YAML, as illustrated below:
 
 ```yaml
   network:

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -67,7 +67,7 @@ The following table includes details on all of the configurable `network` fields
 | `serviceCIDR` | Sets the IPv4 range of IP addresses for services in a Kubernetes cluster. | Valid IPv4 CIDR | `10.96.0.0/16` |
 | `providers` | Sets the provider for the active CNI. | `calico` | `calico` |
 
-## Providers configuration
+## CNI providers configuration
 
 ### Kuberouter CNI
 

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -242,4 +242,4 @@ The network configuration generated as a result of upgrading to MKE 4 from an ex
 
 - MKE4 does not support Calico Enterprise. 
 - Only clusters that use the default Kubernetes proxier `iptables` can be upgraded from MKE3 to MKE4.
-- Only KDD-backed MKE3 clusters can be upgraded to MKE4.
+- Only KDD-backed MKE 3 clusters can be upgraded to MKE 4.

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -5,10 +5,7 @@ weight: 4
 
 MKE supports both the Kuberouter and Calico OSS Container Network Interface (CNI) plugins,
 to enable the networking functionalities needed for container communication
-and management within a cluster:
-
-1. Calico OSS
-2. Kuberouter
+and management within a cluster.
 
 {{< callout type="warning" >}}
 

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -3,7 +3,7 @@ title: Container Network Interface
 weight: 4
 ---
 
-MKE supports the following Container Network Interface (CNI) plugins
+MKE supports both the Kuberouter and Calico OSS Container Network Interface (CNI) plugins,
 to enable the networking functionalities needed for container communication
 and management within a cluster:
 

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -69,7 +69,7 @@ The following table includes details on all of the configurable `network` fields
 
 ## CNI providers configuration
 
-### Kuberouter CNI
+### Kuberouter
 
 Configuration for the kube-router CNI can be done by referring to the
 documentation in https://github.com/cloudnativelabs/kube-router/blob/master/docs/user-guide.md#command-line-options. 

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -154,7 +154,7 @@ The default network configuration described herein offers a serviceable, low mai
 {{< callout type="important" >}}
 
 - You must choose whether to specify an exact YAML specification for the Helm installation of Tigera Operator during the initial cluster installation.
-- The supplied yaml for `values.yaml` must include the exact first line `kubeletVolumePluginPath: /var/lib/k0s/kubelet`, otherwise the MKE 4 installation will fail.
+- The supplied YAML for `values.yaml` must include the exact first line `kubeletVolumePluginPath: /var/lib/k0s/kubelet`, otherwise the MKE 4 installation will fail.
 
 {{< /callout >}}
 

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -151,12 +151,23 @@ The default network configuration described herein offers a serviceable, low mai
       provider: kuberouter
 ```
 
-[^0]: The choice of whether to specify exact yaml spec for Helm installation of tigera-operator must be made while initially installing the cluster
-[^1]: MKE4 installation will fail if the supplied yaml for values.yaml does not include the exact first line `kubeletVolumePluginPath: /var/lib/k0s/kubelet`
-[^2]  The full values.yaml spec for the Helm chart used to install tigera-operator can be seen in https://github.com/projectcalico/calico/blob/master/charts/tigera-operator/values.yaml. Refer to 
-      Calico OSS documentation for tigera-operator to prepare the required contents in values.yaml. MKE4 does not mangle the yaml provided in values.yaml before passing it to the Helm installer
-[^3]: Refer to https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation for installation contents in values.yaml
-[^4]: Refer to https://docs.tigera.io/calico/latest/reference/resources/felixconfig for defaultFelixConfiguration contents in values.yaml
+{{< callout type="important" >}}
+
+- You must choose whether to specify an exact YAML specification for the Helm installation of Tigera Operator during the initial cluster installation.
+- The supplied yaml for `values.yaml` must include the exact first line `kubeletVolumePluginPath: /var/lib/k0s/kubelet`, otherwise the MKE 4 installation will fail.
+
+{< /callout >}}
+
+{{< callout type="info" >}} Refer to the official Tigera Operator documentation
+for:
+
+- [Information on how to prepare the required content for the `values.yaml` specification](https://docs.tigera.io/calico/latest/getting-started/kubernetes/windows-calico/operator)
+- The [`values.yaml` information content](https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.Installation)
+- The [`defaultFelixConfiguration` content for the `values.yaml` specification(https://docs.tigera.io/calico/latest/reference/resources/felixconfig)
+
+You can  view the full `values.yaml` specification for the Helm chart needed to install Tigera Operator at the [Project Calico GitHub](https://github.com/projectcalico/calico/blob/master/charts/tigera-operator/values.yaml).
+
+{{< /callout >}}
 The network configuration generated as a result of upgrading to MKE 4 from an existing MKE 3 cluster always uses yaml. As such clusters have at least one existing IP pool, however, the CIDR and dataplane values are specified outside of the yaml, as illustrated below:
 
 ```yaml

--- a/content/docs/concepts/cni.md
+++ b/content/docs/concepts/cni.md
@@ -9,7 +9,7 @@ and management within a cluster.
 
 {{< callout type="warning" >}}
 
-Only Calico OSS CNI is supported for migrating configuration during the MKE3 to MKE4 upgrade.
+Calico OSS is the only CNI that is supported for migrating configuration during an MKE3 to MKE4 upgrade.
 
 {{< /callout >}}
 


### PR DESCRIPTION
Updates the networking information taking into account the move to tigera-operator and allowing a direct yaml spec.